### PR TITLE
Use the Stater interface instead of pgxpool.Pool structure

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -5,10 +5,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Stater defines a method for retrieving statistics from pgxpool.
+// The method returns a pointer to a pgxpool.Stat struct,
+// which contains various metrics and statistics about the
+// connection pool.
+type Stater interface {
+	Stat() *pgxpool.Stat
+}
+
 // PgxPoolStatsCollector is a Prometheus collector for pgx metrics.
 // It implements the prometheus.Collector interface.
 type PgxPoolStatsCollector struct {
-	db *pgxpool.Pool
+	db Stater
 
 	acquireConns            *prometheus.Desc
 	canceledAcquireCount    *prometheus.Desc
@@ -27,7 +35,7 @@ type PgxPoolStatsCollector struct {
 // The db parameter is the pgxpool.Pool to collect metrics from.
 // The db parameter must not be nil.
 // The dbName parameter must not be empty.
-func NewPgxPoolStatsCollector(db *pgxpool.Pool, dbName string) *PgxPoolStatsCollector {
+func NewPgxPoolStatsCollector(db Stater, dbName string) *PgxPoolStatsCollector {
 	fqName := func(name string) string {
 		return prometheus.BuildFQName("pgx", "pool", name)
 	}


### PR DESCRIPTION
This pull request refactors the `cmackenzie1/pgxpool-prometheus` library to use the `Stater` interface instead of directly using the `pgxpool.Pool` struct. This change aims to improve the flexibility and testability of the code by allowing different implementations of the `Stat` method. This change promotes better abstraction and separation of concerns, making the codebase cleaner and more modular. The usage is not changed.